### PR TITLE
fix(interactive): stabilize root search menu rendering

### DIFF
--- a/src/commands/interactive/index.ts
+++ b/src/commands/interactive/index.ts
@@ -70,6 +70,7 @@ export function formatRootSearchDescription(
   if (!description || options.includeDescriptions === false) return undefined;
 
   const singleLine = description.replace(/\s+/g, " ").trim();
+  if (singleLine.length === 0) return undefined;
   const columns = typeof options.columns === "number" && options.columns > 0 ? options.columns : process.stdout.columns;
   const maxLength = Math.max(24, Math.min(100, (columns ?? 80) - 3));
 

--- a/src/commands/interactive/index.ts
+++ b/src/commands/interactive/index.ts
@@ -46,6 +46,7 @@ export const ROOT_SEARCH_PAGE_SIZE = {
   default: 12,
   max: 15,
   reservedRows: 6,
+  minRowsForDescriptions: 24,
 } as const;
 
 export function getRootSearchPageSize(rows = process.stdout.rows): number {
@@ -118,7 +119,7 @@ export async function interactiveMenu(): Promise<string[] | null> {
   for (;;) {
     const pageSize = getRootSearchPageSize();
     const columns = process.stdout.columns;
-    const includeDescriptions = (process.stdout.rows ?? ROOT_SEARCH_PAGE_SIZE.default) >= 24;
+    const includeDescriptions = (process.stdout.rows ?? ROOT_SEARCH_PAGE_SIZE.default) >= ROOT_SEARCH_PAGE_SIZE.minRowsForDescriptions;
 
     const { action } = await inquirer.prompt<{ action: string }>([
       {

--- a/src/commands/interactive/index.ts
+++ b/src/commands/interactive/index.ts
@@ -41,12 +41,45 @@ const DIRECT_COMMANDS = new Set([
   "regression-status", "regression-reset",
 ]);
 
-export function buildSearchSource(term: string | undefined): Choice[] {
-  const all = buildMainChoices();
-  if (!term) return all;
+export const ROOT_SEARCH_PAGE_SIZE = {
+  min: 6,
+  default: 12,
+  max: 15,
+  reservedRows: 6,
+} as const;
 
+export function getRootSearchPageSize(rows = process.stdout.rows): number {
+  if (typeof rows !== "number" || !Number.isFinite(rows) || rows <= 0) {
+    return ROOT_SEARCH_PAGE_SIZE.default;
+  }
+
+  const availableRows = Math.max(0, rows - ROOT_SEARCH_PAGE_SIZE.reservedRows);
+  const candidate = Math.floor(availableRows * 0.6);
+  return Math.min(ROOT_SEARCH_PAGE_SIZE.max, Math.max(ROOT_SEARCH_PAGE_SIZE.min, candidate));
+}
+
+export interface SearchSourceOptions {
+  columns?: number;
+  includeDescriptions?: boolean;
+}
+
+export function formatRootSearchDescription(
+  description: string | undefined,
+  options: SearchSourceOptions = {},
+): string | undefined {
+  if (!description || options.includeDescriptions === false) return undefined;
+
+  const singleLine = description.replace(/\s+/g, " ").trim();
+  const columns = typeof options.columns === "number" && options.columns > 0 ? options.columns : process.stdout.columns;
+  const maxLength = Math.max(24, Math.min(100, (columns ?? 80) - 3));
+
+  if (singleLine.length <= maxLength) return singleLine;
+  return `${singleLine.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function filterRootSearchChoices(choices: Choice[], term: string): Choice[] {
   const lower = term.toLowerCase();
-  const filtered = all.filter((c) => {
+  return choices.filter((c) => {
     if ("type" in c && c.type === "separator") return false;
     const choice = c as { name: string; value: string; description?: string };
     return (
@@ -55,23 +88,44 @@ export function buildSearchSource(term: string | undefined): Choice[] {
       (choice.description?.toLowerCase().includes(lower) ?? false)
     );
   });
+}
 
-  if (!filtered.some((c) => "value" in c && c.value === "exit")) {
-    filtered.push({ name: chalk.dim("  Exit"), value: "exit" });
-  }
+function ensureExitChoice(choices: Choice[]): Choice[] {
+  if (choices.some((c) => "value" in c && c.value === "exit")) return choices;
+  return [...choices, { name: chalk.dim("  Exit"), value: "exit" }];
+}
 
-  return filtered;
+function formatChoiceForRootSearchDisplay(
+  choice: Choice,
+  options: SearchSourceOptions,
+): Choice {
+  if (!("description" in choice)) return choice;
+  return {
+    ...choice,
+    description: formatRootSearchDescription(choice.description, options),
+  };
+}
+
+export function buildSearchSource(term: string | undefined, options: SearchSourceOptions = {}): Choice[] {
+  const all = buildMainChoices();
+  const matches = !term ? all : filterRootSearchChoices(all, term);
+  const result = ensureExitChoice(matches);
+  return result.map((choice) => formatChoiceForRootSearchDisplay(choice, options));
 }
 
 export async function interactiveMenu(): Promise<string[] | null> {
   for (;;) {
+    const pageSize = getRootSearchPageSize();
+    const columns = process.stdout.columns;
+    const includeDescriptions = (process.stdout.rows ?? ROOT_SEARCH_PAGE_SIZE.default) >= 24;
+
     const { action } = await inquirer.prompt<{ action: string }>([
       {
         type: "search",
         name: "action",
         message: "What would you like to do?",
-        source: buildSearchSource,
-        pageSize: 25,
+        source: (term: string | undefined) => buildSearchSource(term, { columns, includeDescriptions }),
+        pageSize,
       },
     ]);
 

--- a/tests/unit/interactive-modules.test.ts
+++ b/tests/unit/interactive-modules.test.ts
@@ -5,6 +5,9 @@ describe("interactive module exports", () => {
     const interactive = await import("../../src/commands/interactive/index.js");
     expect(interactive.interactiveMenu).toBeDefined();
     expect(interactive.buildSearchSource).toBeDefined();
+    expect(interactive.getRootSearchPageSize).toBeDefined();
+    expect(interactive.ROOT_SEARCH_PAGE_SIZE).toBeDefined();
+    expect(interactive.formatRootSearchDescription).toBeDefined();
   });
 });
 

--- a/tests/unit/interactive.test.ts
+++ b/tests/unit/interactive.test.ts
@@ -1,5 +1,10 @@
 import inquirer from "inquirer";
-import { interactiveMenu, buildSearchSource } from "../../src/commands/interactive/index.js";
+import {
+  interactiveMenu,
+  buildSearchSource,
+  getRootSearchPageSize,
+  ROOT_SEARCH_PAGE_SIZE,
+} from "../../src/commands/interactive/index.js";
 
 jest.mock("inquirer");
 
@@ -67,6 +72,16 @@ describe("buildSearchSource", () => {
   });
 });
 
+describe("root search render config", () => {
+  it("uses the spec page-size formula for common terminal heights", () => {
+    expect(getRootSearchPageSize(24)).toBe(10);
+    expect(getRootSearchPageSize(40)).toBe(15);
+    expect(getRootSearchPageSize(200)).toBe(15);
+    expect(getRootSearchPageSize(10)).toBe(ROOT_SEARCH_PAGE_SIZE.min);
+    expect(getRootSearchPageSize(undefined)).toBe(ROOT_SEARCH_PAGE_SIZE.default);
+  });
+});
+
 describe("interactiveMenu", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,6 +97,16 @@ describe("interactiveMenu", () => {
   it("returns null when exit is selected", async () => {
     mockedInquirer.prompt.mockResolvedValueOnce({ action: "exit" });
     expect(await interactiveMenu()).toBeNull();
+    expect(mockedInquirer.prompt).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: "search",
+        name: "action",
+        message: "What would you like to do?",
+        pageSize: expect.any(Number),
+      }),
+    ]);
+    const promptConfig = (mockedInquirer.prompt.mock.calls[0][0] as unknown as Array<{ pageSize: number }>)[0];
+    expect(promptConfig.pageSize).toBeLessThanOrEqual(ROOT_SEARCH_PAGE_SIZE.max);
   });
 
   it.each(["list", "add", "destroy", "restart", "remove", "restore", "export", "config"])(

--- a/tests/unit/interactive.test.ts
+++ b/tests/unit/interactive.test.ts
@@ -107,6 +107,19 @@ describe("root search render config", () => {
     expect(getRootSearchPageSize(10)).toBe(ROOT_SEARCH_PAGE_SIZE.min);
     expect(getRootSearchPageSize(undefined)).toBe(ROOT_SEARCH_PAGE_SIZE.default);
   });
+
+  // M1 (P148 post-execute): explicit guard tests lock the
+  // `typeof rows !== "number" || !Number.isFinite(rows) || rows <= 0` branch
+  // independently of `process.stdout.rows` test-env coupling.
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["-Infinity", -Infinity],
+  ])("returns default for %s rows", (_label, rows) => {
+    expect(getRootSearchPageSize(rows)).toBe(ROOT_SEARCH_PAGE_SIZE.default);
+  });
 });
 
 describe("interactiveMenu", () => {

--- a/tests/unit/interactive.test.ts
+++ b/tests/unit/interactive.test.ts
@@ -89,6 +89,19 @@ describe("buildSearchSource", () => {
     expect(init.description).toBeUndefined();
   });
 
+  it("collapses whitespace-only descriptions to undefined (string|undefined contract)", () => {
+    // formatRootSearchDescription("   ") used to return "" — Inquirer renders "" as a
+    // visible blank description line. After fix, whitespace-only collapses to undefined
+    // (description key absent on the choice), matching the `string | undefined` contract.
+    expect(buildSearchSource).toBeDefined();
+    // Direct formatRootSearchDescription test:
+    const { formatRootSearchDescription } = jest.requireActual(
+      "../../src/commands/interactive/index.js",
+    ) as typeof import("../../src/commands/interactive/index.js");
+    expect(formatRootSearchDescription("   ")).toBeUndefined();
+    expect(formatRootSearchDescription("\n\t  \n")).toBeUndefined();
+  });
+
   it("preserves separator/exit invariants across broad and filtered states", () => {
     const broad = buildSearchSource(undefined, { columns: 80 });
     expect(broad.some((c) => "type" in c && c.type === "separator")).toBe(true);

--- a/tests/unit/interactive.test.ts
+++ b/tests/unit/interactive.test.ts
@@ -70,6 +70,33 @@ describe("buildSearchSource", () => {
     const choices = buildSearchSource("BACKUP");
     expect(choices.some((c: unknown) => typeof c === "object" && c !== null && "value" in c && (c as { value: string }).value === "backup")).toBe(true);
   });
+
+  it("matches original description text even when display descriptions are shortened", () => {
+    const choices = buildSearchSource("Hetzner", { columns: 32 });
+    const init = choices.find((c) => "value" in c && c.value === "init") as { description?: string };
+
+    expect(init).toBeDefined();
+    expect(init.description).toBeDefined();
+    expect(init.description).not.toContain("\n");
+    expect(init.description!.length).toBeLessThanOrEqual(29);
+  });
+
+  it("can hide descriptions on constrained terminals while preserving matches", () => {
+    const choices = buildSearchSource("provision", { columns: 20, includeDescriptions: false });
+    const init = choices.find((c) => "value" in c && c.value === "init") as { description?: string };
+
+    expect(init).toBeDefined();
+    expect(init.description).toBeUndefined();
+  });
+
+  it("preserves separator/exit invariants across broad and filtered states", () => {
+    const broad = buildSearchSource(undefined, { columns: 80 });
+    expect(broad.some((c) => "type" in c && c.type === "separator")).toBe(true);
+
+    const filtered = buildSearchSource("deploy", { columns: 80 });
+    expect(filtered.some((c) => "type" in c && c.type === "separator")).toBe(false);
+    expect(filtered.some((c) => "value" in c && c.value === "exit")).toBe(true);
+  });
 });
 
 describe("root search render config", () => {

--- a/tests/unit/notify.test.ts
+++ b/tests/unit/notify.test.ts
@@ -43,9 +43,15 @@ jest.mock("../../src/utils/secureWrite", () => ({
   secureWriteFileSync: jest.fn(),
 }));
 
-// NOTE: createSpinner is NOT mocked — module mock doesn't apply reliably.
-// testChannel tests (all describe blocks at the end of the file) call createSpinner
-// which causes a TypeError. Those tests are marked with test.skip.
+// NOTE: createSpinner needs a fresh ora mock impl after the global beforeEach's
+// jest.resetAllMocks() runs (D4 batch — P148 post-execute). The 4 unskipped
+// testChannel describe blocks re-install the impl on the ora default export
+// inside their own beforeEach, so testChannel can call createSpinner() safely.
+// Manual mock at tests/__mocks__/ora.ts provides the default impl on cold start;
+// after every resetAllMocks the impl is gone, so we re-create it inline below.
+// See TEST-NOTIFY-D4 fixture in describe blocks: telegram / discord / slack.
+import ora from "ora";
+import { createMockSpinner } from "../__mocks__/ora.js";
 
 // Manual mock at tests/__mocks__/inquirer.ts takes precedence; no inline mock needed.
 // The manual mock exports: { prompt: jest.fn(), Separator } as default export.
@@ -657,15 +663,15 @@ describe("testChannel — channel not configured", () => {
   });
 });
 
-// testChannel requires createSpinner which cannot be mocked reliably (ESM module mock path issue)
-describe.skip("testChannel — telegram success", () => {
+describe("testChannel — telegram success", () => {
   beforeEach(() => {
+    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       telegram: { botToken: "123456:ABCdef_GHI-jkl", chatId: "-100123456" },
     });
   });
 
-  test.skip("sends a test message to configured telegram channel", async () => {
+  test("sends a test message to configured telegram channel", async () => {
     mockedAxiosPost.mockResolvedValue({ data: { ok: true }, status: 200 });
 
     await testChannel("telegram");
@@ -678,15 +684,15 @@ describe.skip("testChannel — telegram success", () => {
   });
 });
 
-// testChannel requires createSpinner which cannot be mocked reliably
-describe.skip("testChannel — telegram failure", () => {
+describe("testChannel — telegram failure", () => {
   beforeEach(() => {
+    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       telegram: { botToken: "123456:ABCdef_GHI-jkl", chatId: "-100123456" },
     });
   });
 
-  test.skip("logs error when telegram send fails", async () => {
+  test("logs error when telegram send fails", async () => {
     mockedAxiosPost.mockRejectedValue(new Error("Bot was blocked"));
 
     await testChannel("telegram");
@@ -695,9 +701,9 @@ describe.skip("testChannel — telegram failure", () => {
   });
 });
 
-// testChannel requires createSpinner which cannot be mocked reliably
-describe.skip("testChannel — discord success", () => {
+describe("testChannel — discord success", () => {
   beforeEach(() => {
+    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       discord: { webhookUrl: "https://discord.com/api/webhooks/1/abc" },
     });
@@ -716,9 +722,9 @@ describe.skip("testChannel — discord success", () => {
   });
 });
 
-// testChannel requires createSpinner which cannot be mocked reliably
-describe.skip("testChannel — slack success", () => {
+describe("testChannel — slack success", () => {
   beforeEach(() => {
+    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       slack: { webhookUrl: "https://hooks.slack.com/services/T/B/s" },
     });

--- a/tests/unit/notify.test.ts
+++ b/tests/unit/notify.test.ts
@@ -43,13 +43,9 @@ jest.mock("../../src/utils/secureWrite", () => ({
   secureWriteFileSync: jest.fn(),
 }));
 
-// NOTE: createSpinner needs a fresh ora mock impl after the global beforeEach's
-// jest.resetAllMocks() runs (D4 batch — P148 post-execute). The 4 unskipped
-// testChannel describe blocks re-install the impl on the ora default export
-// inside their own beforeEach, so testChannel can call createSpinner() safely.
-// Manual mock at tests/__mocks__/ora.ts provides the default impl on cold start;
-// after every resetAllMocks the impl is gone, so we re-create it inline below.
-// See TEST-NOTIFY-D4 fixture in describe blocks: telegram / discord / slack.
+// Manual ora mock at tests/__mocks__/ora.ts provides the default impl.
+// The global beforeEach re-installs it after jest.resetAllMocks() so
+// testChannel can call createSpinner() without per-describe reinstalls.
 import ora from "ora";
 import { createMockSpinner } from "../__mocks__/ora.js";
 
@@ -69,6 +65,7 @@ const mockedLoadNotifyChannels = loadNotifyChannels as jest.Mock;
 
 beforeEach(() => {
   jest.resetAllMocks();
+  (ora as jest.Mock).mockImplementation(() => createMockSpinner());
   mockedLoadNotifyChannels.mockReturnValue({});
   // Re-obtain fresh references after resetAllMocks rebuilds module mocks
   (mockedInquirerPrompt as jest.Mock).mockReset();
@@ -665,7 +662,6 @@ describe("testChannel — channel not configured", () => {
 
 describe("testChannel — telegram success", () => {
   beforeEach(() => {
-    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       telegram: { botToken: "123456:ABCdef_GHI-jkl", chatId: "-100123456" },
     });
@@ -686,7 +682,6 @@ describe("testChannel — telegram success", () => {
 
 describe("testChannel — telegram failure", () => {
   beforeEach(() => {
-    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       telegram: { botToken: "123456:ABCdef_GHI-jkl", chatId: "-100123456" },
     });
@@ -703,7 +698,6 @@ describe("testChannel — telegram failure", () => {
 
 describe("testChannel — discord success", () => {
   beforeEach(() => {
-    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       discord: { webhookUrl: "https://discord.com/api/webhooks/1/abc" },
     });
@@ -724,7 +718,6 @@ describe("testChannel — discord success", () => {
 
 describe("testChannel — slack success", () => {
   beforeEach(() => {
-    (ora as jest.Mock).mockImplementation(() => createMockSpinner());
     mockedLoadNotifyChannels.mockReturnValue({
       slack: { webhookUrl: "https://hooks.slack.com/services/T/B/s" },
     });


### PR DESCRIPTION
## Summary
- bound root interactive search page size and make displayed descriptions one-line/optional
- preserve searchable root menu semantics, separators for broad view, and Exit for filtered view
- enable previously skipped notification channel tests via stable ora mock reinstall

## Verification
- npm run build
- npm run lint
- npx jest tests/unit/interactive.test.ts tests/unit/interactive-modules.test.ts tests/e2e/interactive/index.test.ts tests/unit/notify.test.ts --runInBand
- npm test -- --runInBand
- npm run test:coverage -- --runInBand
- npx jest tests/e2e/interactive/index.test.ts --runInBand

Notes: broad local 
px jest tests/e2e --runInBand has 369/369 assertions pass but exits nonzero from pre-existing PIPEWRAP open-handle diagnostics in TTY-touching e2e; focused interactive E2E is green. Inquirer 14 remains split due engine-policy gate.