### PR TITLE
fix(security): close Vultr/Linode token redaction + qs CVE-2026-8723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -811,6 +812,7 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -822,6 +824,7 @@
       "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2637,9 +2640,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,9 +2655,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2675,9 +2672,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,9 +2688,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2712,9 +2703,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2885,6 +2873,7 @@
       "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.1",
@@ -3648,6 +3637,7 @@
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3728,6 +3718,7 @@
       "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.1",
         "@typescript-eslint/types": "8.62.1",
@@ -4323,6 +4314,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4686,6 +4678,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -5412,6 +5405,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6438,6 +6432,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6814,6 +6809,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8851,12 +8847,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -9148,14 +9145,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -9167,13 +9164,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9583,6 +9580,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9838,28 +9836,13 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/typed-rest-client/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10413,6 +10396,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
   },
   "overrides": {
     "minimatch": "^10.2.4",
-    "ip-address": "^10.1.1"
+    "ip-address": "^10.1.1",
+    "qs": "^6.15.2"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -119,6 +119,7 @@ export const SENSITIVE_KEY_PATTERNS: readonly RegExp[] = [
 export const PROVIDER_TOKEN_PATTERNS: readonly RegExp[] = [
   /^[A-Za-z0-9._-]*hcic_[A-Za-z0-9]+$/, // Hetzner
   /^dop_v1_[A-Za-z0-9]+$/, // DigitalOcean
+  /^vltc[._-]?[A-Za-z0-9]{20,}$/, // Vultr v2 (security-cleanup-1) — `vltc` prefix + opt separator + 20+ alnum body
 ];
 
 // String-shape patterns.
@@ -145,9 +146,14 @@ export const PROVIDER_TOKEN_PATTERNS: readonly RegExp[] = [
 //     "Bearer missing in config" are not collapsed to [REDACTED].
 //   - JWT (3-segment dot-separated with 20+ char segments — the floor
 //     prevents IPv4 like "203.0.113.42" matching "203.0.113").
+//   - Long opaque token (security-cleanup-1) — 50+ char alphanumeric with
+//     no spaces/dots/slashes. Catches Linode-style tokens (no public prefix).
+//     The 50-char floor avoids false-positives on SHA-1 (40 hex), SHA-256
+//     truncated base64 (43 chars), and UUIDs (32-36 chars).
 const WHOLE_STRING_PATTERNS: readonly RegExp[] = [
   /^Bearer\s+[A-Za-z0-9._+/=_-]{8,}$/i,
   /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}$/,
+  /^[A-Za-z0-9]{50,}$/,
 ];
 
 // SUBSTRING_PATTERNS: BEARER substring match uses a (^|\W) word-boundary
@@ -161,6 +167,7 @@ const SUBSTRING_PATTERNS: readonly RegExp[] = [
   /(^|\W)Bearer\s+[A-Za-z0-9._+/=_-]{8,}/gi,
   /hcic_[A-Za-z0-9]+/g,
   /dop_v1_[A-Za-z0-9]+/g,
+  /vltc[._-]?[A-Za-z0-9]{20,}/g, // Vultr v2 embedded (security-cleanup-1)
   /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/g,
 ];
 

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -278,6 +278,56 @@ describe("logger", () => {
     expect(out).toContain("203.0.113.42");
   });
 
+  it("should redact Vultr v2 token as whole-string (provider token gap)", () => {
+    // Vultr v2 API keys use the `vltc` prefix followed by an optional separator
+    // and 32-char alphanumeric body (per Vultr docs). Pre-fix, no PROVIDER_TOKEN
+    // pattern matched Vultr, so the whole token would leak to stderr.
+    const vultrKey = "vltc.AbCdEfGhIjKlMnOpQrStUvWxYz012345";
+    logger.error(vultrKey);
+    const out = stderrSpy.mock.calls
+      .map((call) => call.map((p: unknown) => String(p)).join(" "))
+      .join("\n");
+    expect(out).not.toContain(vultrKey);
+    expect(out).toContain("[REDACTED]");
+  });
+
+  it("should redact Vultr v2 token embedded mid-string (substring redaction)", () => {
+    // Substring path: provider token inside a longer diagnostic message.
+    const vultrKey = "vltc.AbCdEfGhIjKlMnOpQrStUvWxYz012345";
+    logger.error(`auth failed: token=${vultrKey} user=alice`);
+    const out = stderrSpy.mock.calls
+      .map((call) => call.map((p: unknown) => String(p)).join(" "))
+      .join("\n");
+    expect(out).not.toContain(vultrKey);
+    expect(out).toContain("auth failed");
+    expect(out).toContain("alice");
+  });
+
+  it("should redact long opaque tokens as whole-string (Linode-style, no public prefix)", () => {
+    // Linode doesn't publish its token prefix (security through obscurity).
+    // Tokens are long opaque alphanumeric strings used as Bearer auth, typically
+    // 50+ chars. The whole-string pattern catches them; the 50-char floor
+    // avoids false-positives on commit hashes (40 hex) and UUIDs (32-36 chars).
+    const linodeKey = "aB3cD4eF5gH6iJ7kL8mN9oP0qR1sT2uV3wX4yZ5aB6cD7eF8gH9";
+    logger.error(linodeKey);
+    const out = stderrSpy.mock.calls
+      .map((call) => call.map((p: unknown) => String(p)).join(" "))
+      .join("\n");
+    expect(out).not.toContain(linodeKey);
+    expect(out).toContain("[REDACTED]");
+  });
+
+  it("should NOT redact short hex hashes when length below the long-token floor", () => {
+    // Regression guard: SHA-1 (40 hex) and similar short identifiers must NOT
+    // be redacted. The 50-char whole-string floor keeps them visible.
+    const sha1 = "5d41402abc4b2a76b9719d911017c592";
+    logger.info(`commit ${sha1}`);
+    const out = stdoutSpy.mock.calls
+      .map((call) => call.map((p: unknown) => String(p)).join(" "))
+      .join("\n");
+    expect(out).toContain(sha1);
+  });
+
   it("should log title with empty lines before and after", () => {
     logger.title("My Title");
     expect(stdoutSpy).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
Resolves GitHub Security alerts:

**CodeQL (3 HIGH alerts):**
- #49 — src/utils/logger.ts:52 — js/clear-text-logging
- #50 — src/utils/logger.ts:78 — js/clear-text-logging
- #51 — src/utils/logger.ts:80 — js/clear-text-logging

Root cause: redaction patterns in PROVIDER_TOKEN_PATTERNS only covered Hetzner (hcic_) and DigitalOcean (dop_v1_). Vultr v2 (vltc prefix) and Linode (no public prefix) tokens were not scrubbed.

Fix: 3 additive patterns + tests.
1. PROVIDER_TOKEN_PATTERNS: Vultr v2 (^vltc[._-]?[A-Za-z0-9]{20,}$)
2. WHOLE_STRING_PATTERNS: long opaque tokens 50+ char (catches Linode-style, floor avoids SHA-1/SHA-256/UUID false-positives)
3. SUBSTRING_PATTERNS: Vultr v2 embedded (vltc[._-]?[A-Za-z0-9]{20,})

**Dependabot (1 MEDIUM alert):**
- #28 — qs CVE-2026-8723 (DoS in qs.stringify when encodeValuesOnly + null/undefined entries)
- Affected: >=6.11.1 <6.15.2 / Fixed: 6.15.2
- qs is transitive (@modelcontextprotocol/sdk→express→body-parser production + @stryker-mutator→typed-rest-client dev)
- Fix: top-level override ^6.15.2 (resolved to 6.15.3) — mirrors P147 release-blocker pattern

## Verification

- TDD: RED verified (3 failing tests), GREEN verified (56/56 logger.test.ts pass)
- npx eslint src/ → clean exit 0
- npm run build → tsc + bundle-mcp PASS (dist/mcp-bundle.mjs created)
- npm test → 12154/12154 PASS, 380 suites
- npm ls qs → all trees qs@6.15.3 (deduped)
- npm install --package-lock-only → 0 vulnerabilities

## Atomic Commits

- 22fd4ad5 fix(logger): close Vultr + Linode token redaction gap
- 42ecab6c fix(deps): override qs to ^6.15.2 for CVE-2026-8723