### PR TITLE
fix(logger): suppress CodeQL js/clear-text-logging false positives (alerts #49-51)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -49,6 +49,7 @@ export const logger = {
     const args = context
       ? [chalk.red("✖"), message, context]
       : [chalk.red("✖"), message];
+    // codeql[js/clear-text-logging] false-positive: args flow through redactArg → redactString/safeStringify (P142/P147/security-cleanup-1 redaction hardening — Vultr/Linode + provider tokens + sensitive keys)
     console.error(...args.map(redactArg));
   },
 
@@ -75,8 +76,10 @@ export const logger = {
 function diagnosticLog(...args: unknown[]): void {
   const redactedArgs = args.map(redactArg);
   if (machineMode) {
+    // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify (security-cleanup-1)
     console.error(...redactedArgs);
   } else {
+    // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify (security-cleanup-1)
     console.log(...redactedArgs);
   }
 }


### PR DESCRIPTION
Resolves CodeQL alerts #49, #50, #51 (all HIGH) on src/utils/logger.ts:52, 78, 80.

## Why these are false positives

Manual data-flow audit confirmed 0 actual sensitive-data leaks to logger calls. Every logger path flows through:

- `diagnosticLog` (used by `logger.info/success/step`):
  - `redactedArgs = args.map(redactArg)` (line 76)
  - `console.error(...redactedArgs)` (line 78) ← alert #50
  - `console.log(...redactedArgs)` (line 80) ← alert #51

- `logger.error`:
  - `console.error(...args.map(redactArg))` (line 52) ← alert #49

`redactArg` applies either `redactString` (string checks against PROVIDER_TOKEN_PATTERNS, WHOLE_STRING_PATTERNS, SUBSTRING_PATTERNS) or `safeStringify` (recursive sensitive-key redaction per SENSITIVE_KEY_PATTERNS — /password/i, /secret/i, /token/i, /apikey/i, /authorization/i, /credential/i, /private[_-]?key/i).

CodeQL's `js/clear-text-logging` rule doesn't recognize `redactArg` as a sanitizer, so it flags every sink that data flows to after touching password/passphrase/auth-adjacent sources (the "passwordAuth" category in CodeQL semantics).

## Fix

3 suppression comments at the flagged sink lines. CodeQL recognizes these and marks the alerts as suppressed on next scan.

```typescript
// codeql[js/clear-text-logging] false-positive: args flow through redactArg → redactString/safeStringify (P142/P147/security-cleanup-1 redaction hardening)
console.error(...args.map(redactArg));
```

## Verification

- npx eslint src/ → clean exit 0
- npx jest tests/unit/logger.test.ts → 56/56 PASS (incl. 5 redaction tests from PR #51)
- No functional code change — comment-only fix

## Atomic commit

- 875dd009 fix(logger): suppress CodeQL js/clear-text-logging false positives (alerts #49-51) (1 file, +3 lines)

Closes the 3 CodeQL alerts left open after PR #51 merge.