### PR TITLE
fix(logger): use inline codeql suppression for alerts #49 + #51

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -49,8 +49,7 @@ export const logger = {
     const args = context
       ? [chalk.red("✖"), message, context]
       : [chalk.red("✖"), message];
-    // codeql[js/clear-text-logging] false-positive: args flow through redactArg → redactString/safeStringify (P142/P147/security-cleanup-1 redaction hardening — Vultr/Linode + provider tokens + sensitive keys)
-    console.error(...args.map(redactArg));
+    console.error(...args.map(redactArg)); // codeql[js/clear-text-logging] false-positive: args flow through redactArg → redactString/safeStringify
   },
 
   warning: (message: string) => {
@@ -76,11 +75,10 @@ export const logger = {
 function diagnosticLog(...args: unknown[]): void {
   const redactedArgs = args.map(redactArg);
   if (machineMode) {
-    // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify (security-cleanup-1)
+    // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify
     console.error(...redactedArgs);
   } else {
-    // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify (security-cleanup-1)
-    console.log(...redactedArgs);
+    console.log(...redactedArgs); // codeql[js/clear-text-logging] false-positive: redactedArgs pre-redacted via redactArg → redactString/safeStringify
   }
 }
 


### PR DESCRIPTION
Follows up PR #52 (which closed only #50 of 3 CodeQL alerts). Post-merge re-scan showed inline suppression is more reliable for #49 and #51.

Changes: 2 suppression comments moved from line-before to inline (same line as the console call). No functional code change.

Closes CodeQL alerts #49 and #51 (alert #50 already fixed in PR #52).